### PR TITLE
fix: release permissions in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write  # Required for creating releases and uploading assets
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR fixes permission issues in the Clodo release workflow by updating the workflow configuration to grant appropriate access. This ensures successful deployments during CI runs.